### PR TITLE
Script to add moderator actions to a record

### DIFF
--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -1,0 +1,110 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A reddit bot to detect which actions subreddit moderators actually took."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+from datetime import datetime
+import json
+import praw
+import time
+
+from creds import creds
+
+
+def write_moderator_actions(reddit,
+                            line,
+                            id_key,
+                            timestamp_key,
+                            output_path,
+                            hours_to_wait):
+  record = json.loads(line)
+  comment = reddit.comment(record[id_key])
+  maybe_wait(record[timestamp_key], hours_to_wait)
+  record['approved'] = comment.approved
+  record['removed'] = comment.removed
+  with open(output_path, 'a') as o:
+    json.dump(record, o)
+    o.write('\n')
+
+
+def maybe_wait(timestamp, hours_to_wait):
+  """Waits until hours_to_wait hours have passed since timestamp"""
+
+  now = datetime.utcnow()
+  time_diff = now - datetime.strptime(timestamp, '%Y%m%d_%H%M%S')
+  time_diff = time_diff.seconds
+  seconds_to_wait = hours_to_wait * 3600
+  if time_diff < seconds_to_wait:
+    time_to_wait = seconds_to_wait - time_diff
+    print('Waiting %.1f seconds...' % time_to_wait)
+    time.sleep(time_to_wait)
+
+
+def _main():
+  parser = argparse.ArgumentParser(
+      'Reads the output of moderate_subreddit.py and adds actions taken by'
+      'human moderators.')
+  parser.add_argument('input_path', help='json file with reddit comment ids')
+  parser.add_argument('output_path', help='path to write output file')
+  parser.add_argument('-id_key', help='json key containing reddit comment id',
+                      default='comment_id')
+  parser.add_argument('-timestamp_key', help='json key containing timestamp'
+                      'that moderation bot saw comment',
+                      default='bot_review_utc')
+  parser.add_argument('-hours_to_wait',
+                      help='the number of hours to wait to allow moderators to'
+                      ' respond to bot',
+                      type=int,
+                      default=12)
+  parser.add_argument('-stop_at_eof',
+                      help='if set, stops the process once the end of file is '
+                      'hit instead of waiting for new comments to be written',
+                      action='store_true')
+
+  args = parser.parse_args()
+
+  reddit = praw.Reddit(client_id=creds['reddit_client_id'],
+                       client_secret=creds['reddit_client_secret'],
+                       user_agent=creds['reddit_user_agent'],
+                       username=creds['reddit_username'],
+                       password=creds['reddit_password'])
+
+  with open(args.input_path) as f:
+    # Loops through the file and waits at EOF for new data to be written.
+    while True:
+      where = f.tell()
+      line = f.readline()
+      if line:
+        write_moderator_actions(reddit,
+                                line,
+                                args.id_key,
+                                args.timestamp_key,
+                                args.output_path,
+                                args.hours_to_wait)
+      else:
+        if args.stop_at_eof:
+          return
+        else:
+          print('Reached EOF. Waiting for new data...')
+          time.sleep(args.hours_to_wait * 3600)
+          f.seek(where)
+
+
+if __name__ == '__main__':
+  _main()

--- a/perspective_reddit_bot/moderate_subreddit.py
+++ b/perspective_reddit_bot/moderate_subreddit.py
@@ -23,7 +23,6 @@ from collections import defaultdict
 from datetime import datetime
 import os
 import json
-import time
 import praw
 from sets import Set
 import yaml
@@ -148,6 +147,9 @@ def apply_action(action_name, comment, descriptions):
   else:
     raise ValueError('Action "%s" not yet implemented.' % self.action_name)
 
+def timestamp_to_datetime(timestamp):
+  return datetime.utcfromtimestamp(timestamp).strftime('%Y%m%d_%H%M%S')
+
 
 def print_moderation_decision(i, comment, rule):
   print('----------')
@@ -157,6 +159,50 @@ def print_moderation_decision(i, comment, rule):
   print('Action: %s' % rule.action_name)
   print('Subreddit: %s' % comment.subreddit)
 
+def append_comment_data(output_path,
+                        comment,
+                        comment_for_scoring,
+                        action_dict,
+                        scores):
+  with open(output_path, 'a') as f:
+    record = {
+      'comment_id': comment.id,
+      'comment_text': comment.body,
+      'scored_comment_text': comment_for_scoring,
+      'created_utc': timestamp_to_datetime(comment.created_utc),
+      'permalink': 'https://reddit.com' + comment.permalink,
+      'author': comment.author.name,
+      'bot_review_utc': datetime.utcnow().strftime('%Y%m%d_%H%M%S')}
+    record.update(action_dict)
+    record.update(scores)
+    json.dump(record, f)
+    f.write('\n')
+
+def score_comment(comment,
+                  perspective,
+                  api_models,
+                  ensembles,
+                  should_remove_quotes):
+  original_comment = comment.body
+  comment_for_scoring = (remove_quotes(original_comment)
+                          if should_remove_quotes else original_comment)
+  if len(comment_for_scoring) > 20000:
+    print('Comment too long, skipping...')
+    return None, None
+  scores = perspective.score_text(comment_for_scoring, api_models,
+                                  language=LANGUAGE)
+  for e in ensembles:
+    scores[e.name] = e.predict_one(scores)
+
+  return comment_for_scoring, scores
+
+def check_rules(index, comment, rules, scores):
+  action_dict = defaultdict(list)
+  for rule in rules:
+    if rule.check_model_rules(scores):
+      action_dict[rule.action_name].append(rule.rule_description)
+      print_moderation_decision(index, comment, rule)
+  return action_dict
 
 def score_subreddit(creds_dict,
                     subreddit_name,
@@ -164,7 +210,7 @@ def score_subreddit(creds_dict,
                     api_models,
                     ensembles,
                     should_remove_quotes,
-                    output_path=None):
+                    output_dir=None):
   """Score subreddit commments via Perspective API and apply moderation rules.
 
   Args:
@@ -175,9 +221,9 @@ def score_subreddit(creds_dict,
     api_models: (list) A list of models that the API must call to apply rules.
     ensembles: (list) A list of ensemble models based on the API models to
       additionally score each comment with.
-    remove_quotes: (bool) Whether to remove Reddit quotes before scoring.
-    output_path: (str, optional) If supplied, all comments and scores will be
-                 written to this path.
+    should_remove_quotes: (bool) Whether to remove Reddit quotes before scoring.
+    output_dir: (str, optional) If supplied, all comments and scores will be
+                 written to this directory.
   """
 
   reddit = praw.Reddit(client_id=creds_dict['reddit_client_id'],
@@ -199,49 +245,40 @@ def score_subreddit(creds_dict,
   perspective = perspective_client.PerspectiveClient(
     creds_dict['perspective_api_key'])
 
+  current_file_time = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
   for i, comment in enumerate(subreddit.stream.comments()):
     try:
-      # TODO(nthain): Make this loop more readable by breaking into functions.
       if i % 100 == 0 and i > 0:
         print(i)
         # Check if still has mod permissions every 100 comments
         mod_permissions = bot_is_mod(reddit, subreddit)
 
-      original_comment = comment.body
-      comment_for_scoring = (remove_quotes(original_comment)
-                             if should_remove_quotes else original_comment)
-      if len(comment_for_scoring) > 20000:
-        print('Comment too long, skipping...')
+      # Score current comment with perspective models
+      comment_for_scoring, scores = score_comment(comment,
+                                                  perspective,
+                                                  api_models,
+                                                  ensembles,
+                                                  should_remove_quotes)
+      if scores is None:
         continue
-      scores = perspective.score_text(comment_for_scoring, api_models,
-                                      language=LANGUAGE)
-      for e in ensembles:
-        scores[e.name] = e.predict_one(scores)
 
-      action_dict = defaultdict(list)
-      for rule in rules:
-        if rule.check_model_rules(scores):
-          action_dict[rule.action_name].append(rule.rule_description)
-          print_moderation_decision(i, comment, rule)
+      # Check which rules should be applied
+      action_dict = check_rules(i, comment, rules, scores)
 
+      # Apply actions from triggered rules
       if mod_permissions and original_mod_permissions:
         for action, rule_strings in action_dict.items():
           apply_action(action, comment, rule_strings)
 
-      if output_path:
-        with open(output_path, 'a') as f:
-          record = {
-              'comment_id': comment.id,
-              'comment_text': original_comment,
-              'scored_comment_text': comment_for_scoring,
-              'created_utc': comment.created_utc,
-              'permalink': 'https://reddit.com' + comment.permalink,
-              'author': comment.author.name,
-          }
-          record.update(action_dict)
-          record.update(scores)
-          json.dump(record, f)
-          f.write('\n')
+      # Maybe write comment scores to file
+      if output_dir:
+        file_suffix = '%s_%s.json' % (subreddit_name, current_file_time)
+        output_path = os.path.join(output_dir, file_suffix)
+        append_comment_data(output_path,
+                            comment,
+                            comment_for_scoring,
+                            action_dict,
+                            scores)
     except Exception as e:
       print('Skipping comment due to exception: %s' % e)
 
@@ -259,16 +296,10 @@ def _main():
                       default=None)
 
   args = parser.parse_args()
-  if args.output_dir:
-    file_suffix = '%s_%s.json' % (args.subreddit,
-                                  datetime.now().strftime('%Y%m%d_%H%M%S'))
-    output_path = os.path.join(args.output_dir, file_suffix)
 
-  else:
-    output_path = None
   rules, api_models, ensembles = parse_config(args.config_file)
   score_subreddit(creds, args.subreddit, rules, api_models, ensembles,
-                  args.remove_quotes, output_path)
+                  args.remove_quotes, args.output_dir)
 
 if __name__ == '__main__':
   _main()

--- a/perspective_reddit_bot/moderate_subreddit.py
+++ b/perspective_reddit_bot/moderate_subreddit.py
@@ -184,9 +184,9 @@ def score_comment(comment,
                   api_models,
                   ensembles,
                   should_remove_quotes):
-  original_comment = comment.body
-  comment_for_scoring = (remove_quotes(original_comment)
-                          if should_remove_quotes else original_comment)
+  initial_comment = comment.body
+  comment_for_scoring = (remove_quotes(initial_comment)
+                          if should_remove_quotes else initial_comment)
   if len(comment_for_scoring) > 20000:
     print('Comment too long, skipping...')
     return None, None
@@ -233,10 +233,10 @@ def score_subreddit(creds_dict,
                        username=creds_dict['reddit_username'],
                        password=creds_dict['reddit_password'])
   subreddit = reddit.subreddit(subreddit_name)
-  original_mod_permissions = bot_is_mod(reddit, subreddit)
-  mod_permissions = original_mod_permissions
+  initial_mod_permissions = bot_is_mod(reddit, subreddit)
+  recent_mod_permissions = initial_mod_permissions
 
-  if original_mod_permissions:
+  if initial_mod_permissions:
     print('Bot is moderator of subreddit.')
     print('Moderation actions will be applied.')
   else:
@@ -257,7 +257,7 @@ def score_subreddit(creds_dict,
       if i % 100 == 0 and i > 0:
         print(i)
         # Check if still has mod permissions every 100 comments
-        mod_permissions = bot_is_mod(reddit, subreddit)
+        recent_mod_permissions = bot_is_mod(reddit, subreddit)
 
       # Score current comment with perspective models
       comment_for_scoring, scores = score_comment(comment,
@@ -272,7 +272,7 @@ def score_subreddit(creds_dict,
       action_dict = check_rules(i, comment, rules, scores)
 
       # Apply actions from triggered rules
-      if mod_permissions and original_mod_permissions:
+      if recent_mod_permissions and initial_mod_permissions:
         for action, rule_strings in action_dict.items():
           apply_action(action, comment, rule_strings)
 


### PR DESCRIPTION
This PR does the following:
- Refactors moderate_subreddit to simplify the inner loop by pulling more code into functions
- Adds the bot_review_utc timestamp to the record written by the moderate_subreddit_bot
- Adds a bot check_mod_actions which will wait a certain period of time and then check if the moderator acted on any comments written to json by moderate_subreddit bot

This ought to work by:
(1) Running the moderate_subreddit bot with the output_dir set
(2) Run the check_mod_actions bot with the input_path being set to the file created by the moderate_subreddit bot and setting your chosen output_path

N.B. for jetpack: I decided not to shard the output of the moderate subreddit bot as we discussed because I don't think the current interaction is that sensitive to "hiccups"