### PR TITLE
Restructure moderate_subreddit output format to be more normalized.

### DIFF
--- a/perspective_reddit_bot/moderate_subreddit.py
+++ b/perspective_reddit_bot/moderate_subreddit.py
@@ -34,6 +34,8 @@ import config
 # TODO(nthain): support automated language detection.
 LANGUAGE = 'en'
 
+MODEL_SCORE_OUTPUT_PREFIX = 'score:'
+
 
 def timestamp_string(timestamp):
   return datetime.utcfromtimestamp(timestamp).strftime('%Y%m%d_%H%M%S')
@@ -105,7 +107,8 @@ def create_output_record(comment, comment_for_scoring, action_dict, scores):
       for action, rules in action_dict.iteritems()
   }
   record.update(actions_to_rule_descriptions)
-  record.update(scores)
+  record.update({MODEL_SCORE_OUTPUT_PREFIX + model: score
+                 for model, score in scores.iteritems()})
   return record
 
 

--- a/perspective_reddit_bot/moderate_subreddit.py
+++ b/perspective_reddit_bot/moderate_subreddit.py
@@ -30,6 +30,7 @@ import perspective_client
 
 import config
 
+
 # TODO(nthain): support automated language detection.
 LANGUAGE = 'en'
 
@@ -83,6 +84,7 @@ def print_moderation_decision(i, comment, rule):
   print('Action: %s' % rule.action_name)
   print('Subreddit: %s' % comment.subreddit)
 
+
 def append_comment_data(output_path,
                         comment,
                         comment_for_scoring,
@@ -106,6 +108,7 @@ def append_comment_data(output_path,
     json.dump(record, f)
     f.write('\n')
 
+
 def score_comment(comment,
                   perspective,
                   api_models,
@@ -124,6 +127,7 @@ def score_comment(comment,
 
   return comment_for_scoring, scores
 
+
 def check_rules(index, comment, rules, scores):
   action_dict = defaultdict(list)
   for rule in rules:
@@ -131,6 +135,7 @@ def check_rules(index, comment, rules, scores):
       action_dict[rule.action_name].append(rule.rule_description)
       print_moderation_decision(index, comment, rule)
   return action_dict
+
 
 def score_subreddit(creds_dict,
                     subreddit_name,
@@ -231,6 +236,7 @@ def _main():
   rules, api_models, ensembles = config.parse_config(args.config_file)
   score_subreddit(creds, args.subreddit, rules, api_models, ensembles,
                   args.remove_quotes, args.output_dir)
+
 
 if __name__ == '__main__':
   _main()

--- a/perspective_reddit_bot/moderate_subreddit_test.py
+++ b/perspective_reddit_bot/moderate_subreddit_test.py
@@ -1,0 +1,86 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A class for checking and applying moderation rules."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from moderate_subreddit import remove_quotes, check_rules
+from perspective_rule import Rule
+
+
+
+class ModerateSubredditTest(unittest.TestCase):
+
+  def test_remove_quotes(self):
+    comment_without_quoting = 'hi\nyay'
+    self.assertEqual(comment_without_quoting,
+                     remove_quotes(comment_without_quoting))
+    comment_with_quoting = '> hi\nhello there'
+    self.assertEqual('hello there',
+                     remove_quotes(comment_with_quoting))
+    comment_with_lots_of_quoting = '''> hi
+>blah
+hello there
+> yuck
+gross'''
+    self.assertEqual('hello there\ngross',
+                     remove_quotes(comment_with_lots_of_quoting))
+
+  def test_check_rules_simple(self):
+    comment = None  # Comment features aren't used by this test.
+    scores = { 'TOXICITY': 0.9 }
+    rules = [
+        Rule('hi_tox', {'TOXICITY': '> 0.5'}, {}, 'report'),
+    ]
+    actions = check_rules(comment, rules, scores)
+    self.assertEqual(['report'], actions.keys())
+    self.assertEqual(['hi_tox'], [r.name for r in actions['report']])
+
+  def test_check_rules_multiple_triggered_rules(self):
+    comment = None  # Comment features aren't used by this test.
+    # hi_tox and hi_spam are triggered, but not hi_threat.
+    scores = { 'TOXICITY': 0.9, 'SPAM': 0.9, 'THREAT': 0.2 }
+    rules = [
+        Rule('hi_tox', {'TOXICITY': '> 0.5'}, {}, 'report'),
+        Rule('hi_spam', {'SPAM': '> 0.5'}, {}, 'report'),
+        Rule('hi_threat', {'THREAT': '> 0.5'}, {}, 'report'),
+    ]
+    actions = check_rules(comment, rules, scores)
+    self.assertEqual(['report'], actions.keys())
+    self.assertEqual(['hi_tox', 'hi_spam'],
+                     [r.name for r in actions['report']])
+
+  def test_check_rules_multiple_actions(self):
+    comment = None  # Comment features aren't used by this test.
+    scores = { 'TOXICITY': 0.9, 'THREAT': 0.2 }
+    rules = [
+        Rule('hi_tox', {'TOXICITY': '> 0.5'}, {}, 'report'),
+        Rule('hi_threat', {'THREAT': '> 0.9'}, {}, 'report'),
+        Rule('med_threat', {'THREAT': '> 0.1'}, {}, 'noop'),
+    ]
+    actions = check_rules(comment, rules, scores)
+    self.assertEqual(['noop', 'report'], sorted(actions.keys()))
+    self.assertEqual(['hi_tox'],
+                     [r.name for r in actions['report']])
+    self.assertEqual(['med_threat'],
+                     [r.name for r in actions['noop']])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/perspective_reddit_bot/moderate_subreddit_test.py
+++ b/perspective_reddit_bot/moderate_subreddit_test.py
@@ -108,7 +108,7 @@ gross'''
     self.assertEqual('hello', record['orig_comment_text'])
     # This field is only present when different from the comment body.
     self.assertFalse('scored_comment_text' in record)
-    self.assertEqual(0.8, record['TOXICITY'])
+    self.assertEqual(0.8, record['score:TOXICITY'])
     self.assertEqual(['Perspective Bot rule triggered: hi_tox: TOXICITY > 0.5'],
                      record['report'])
 


### PR DESCRIPTION
[Note: this depends on #17, please review that first]

Primary change: output record now has top-level fields for each configured rule. The field name is "score:<rule name>" and the value is the outcome of the rule: either the action ('report', 'noop'), or the special 'rule-not-triggered' value indicating that the rule didn't trigger.

Previously, the output record had fields for actions ('report' and 'noop'), and the corresponding values were lists of rule descriptions that resulted in the action. Untriggered rules weren't mentioned.

This makes the output more regular and easier to deal with down the line (no extra unnesting/processing of the 'report' field, no dealing with null values).

This PR also adds some testing of functions in moderate_subreddit.