### PR TITLE
Change check_mod_actions flag defaults.

### DIFF
--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -30,9 +30,23 @@ import log_subreddit_comments
 import moderate_subreddit
 
 
+# approved, removed, and deleted columns are booleans. 'approved' is only
+# present when the bot is a mod.
 APPROVED_COL = 'approved'
 REMOVED_COL = 'removed'
 DELETED_COL = 'deleted'
+# score, ups, and downs refer to user votes. in practice, it appears that
+# 'downs' is always 0 and 'score' == 'ups'. (this may be different if the bot is
+# a mod.)
+SCORE_COL = 'score'
+UPS_COL = 'ups'
+DOWNS_COL = 'downs'
+SCORE_HIDDEN_COL = 'score_hidden'
+# collapsed is a boolean. it appears to be true when the comment (and all its
+# children) are collapsed in the UI. this most commonly happens when the comment
+# is deleted or removed, but it also seems to happens when the comment has more
+# downvotes
+COLLAPSED_COL = 'collapsed'
 
 FILENAME_OUTPUT_PREFIX = 'modactions'
 
@@ -74,7 +88,12 @@ def fetch_reddit_comment_status(reddit, comment_id, has_mod_creds):
 # user has mod privileges and when it doesn't have mod privileges.
 def get_comment_status(comment, has_mod_creds):
   status = {
-      DELETED_COL: comment.author is None and comment.body == '[deleted]'
+      DELETED_COL: comment.author is None and comment.body == '[deleted]',
+      SCORE_COL: comment.score,
+      UPS_COL: comment.ups,
+      DOWNS_COL: comment.downs,
+      SCORE_HIDDEN_COL: comment.score_hidden,
+      COLLAPSED_COL: comment.collapsed,
   }
   if has_mod_creds:
     status[APPROVED_COL] = comment.approved

--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -54,7 +54,7 @@ def write_moderator_actions(reddit,
   if status_fields is not None:
     record.update(status_fields)
 
-  log_subreddit_comments.append_record(output_path, record)
+  log_subreddit_comments.append_records(output_path, [record])
 
 
 def fetch_reddit_comment_status(reddit, comment_id, has_mod_creds):

--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -160,8 +160,7 @@ def _main():
   output_path = (args.output_path
                  or get_output_filename_from_input(args.input_path))
   if os.path.exists(output_path):
-    raise ValueError(
-        'Auto-generated output filename exists already: {}'.format(output_path))
+    raise ValueError('Output filename exists already: {}'.format(output_path))
 
   with open(args.creds) as f:
     creds = json.load(f)

--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -101,7 +101,10 @@ def drop_prefix(s, pre):
 
 
 # Try to return an output filename based on input filename.
-def get_output_filename_from_input(in_file):
+def get_output_filename_from_input(in_file, hours_to_wait):
+  if int(hours_to_wait) == hours_to_wait:
+    # Drop ".0" suffix when included in filename.
+    hours_to_wait = int(hours_to_wait)
   dirname = os.path.dirname(in_file)
   basename = os.path.basename(in_file)
 
@@ -114,7 +117,8 @@ def get_output_filename_from_input(in_file):
     raise ValueError(
         'Failed to figure out an output path. Specify -output_path explicitly.')
   out_path = os.path.join(
-      dirname, '{}{}'.format(FILENAME_OUTPUT_PREFIX, bare_basename))
+      dirname, '{}_{}delay{}'.format(FILENAME_OUTPUT_PREFIX, hours_to_wait,
+                                     bare_basename))
   print('Auto-generated output path:', out_path)
   return out_path
 
@@ -158,7 +162,8 @@ def _main():
     raise ValueError('must explicitly use either -mod_creds or -no_mod_creds!')
 
   output_path = (args.output_path
-                 or get_output_filename_from_input(args.input_path))
+                 or get_output_filename_from_input(args.input_path,
+                                                   args.hours_to_wait))
   if os.path.exists(output_path):
     raise ValueError('Output filename exists already: {}'.format(output_path))
 

--- a/perspective_reddit_bot/check_mod_actions.py
+++ b/perspective_reddit_bot/check_mod_actions.py
@@ -41,6 +41,9 @@ DELETED_COL = 'deleted'
 SCORE_COL = 'score'
 UPS_COL = 'ups'
 DOWNS_COL = 'downs'
+# score_hidden is a boolean for when the above score-related fields are hidden
+# due to subreddit rules. with a sufficient hours_to_wait delay, this shouldn't
+# be true for the checked comments.
 SCORE_HIDDEN_COL = 'score_hidden'
 # collapsed is a boolean. it appears to be true when the comment (and all its
 # children) are collapsed in the UI. this most commonly happens when the comment

--- a/perspective_reddit_bot/log_subreddit_comments.py
+++ b/perspective_reddit_bot/log_subreddit_comments.py
@@ -50,10 +50,11 @@ def comment_url(comment):
   return 'https://reddit.com' + comment.permalink
 
 
-def append_record(output_path, record):
+def append_records(output_path, records):
   with open(output_path, 'a') as f:
-    json.dump(record, f)
-    f.write('\n')
+    for r in records:
+      json.dump(r, f)
+      f.write('\n')
 
 
 def create_comment_output_record(comment):
@@ -129,7 +130,7 @@ def log_subreddit(creds, subreddits, output_dir):
       sys.stdout.flush()
       output_record = create_comment_output_record(comment)
       if i % 25 == 0: print_comment(i, output_record)
-      append_record(output_path, output_record)
+      append_records(output_path, [output_record])
     except Exception as e:
       print('\n\nEXCEPTION!\nException: {}\nSkipping comment: {}\n', e, comment)
 

--- a/perspective_reddit_bot/log_subreddit_comments.py
+++ b/perspective_reddit_bot/log_subreddit_comments.py
@@ -91,7 +91,7 @@ def comment_stream(stream):
           continue
         seen_comment_ids.append(x.id)
         yield x
-    except prawcore.exceptions.ServerError, e:
+    except prawcore.exceptions.ServerError as e:
       print('\n\nERROR while reading comment stream:', e)
       print('Waiting {} seconds before retrying...'.format(
           _PRAW_STREAM_ERROR_RETRY_WAIT_SECONDS))

--- a/perspective_reddit_bot/moderate_subreddit.py
+++ b/perspective_reddit_bot/moderate_subreddit.py
@@ -29,7 +29,7 @@ import config
 import perspective_client
 from perspective_rule import REPORT_ACTION, NOOP_ACTION
 from log_subreddit_comments import (
-    append_record, comment_stream, comment_url, create_comment_output_record,
+    append_records, comment_stream, comment_url, create_comment_output_record,
     now_timestamp
 )
 
@@ -221,7 +221,7 @@ def score_subreddit(creds_dict,
       if output_path:
         output_record = create_mod_comment_output_record(
             comment, comment_for_scoring, scores, action_dict, rules)
-        append_record(output_path, output_record)
+        append_records(output_path, [output_record])
     except Exception as e:
       print('Skipping comment due to exception: %s' % e)
 

--- a/perspective_reddit_bot/perspective_client.py
+++ b/perspective_reddit_bot/perspective_client.py
@@ -154,7 +154,8 @@ class PerspectiveClient(object):
     every_5_percent = _progress_points(frac=0.05, total=len(texts))
     # pylint: disable=missing-docstring
 
-    def score_one((i, text)):
+    def score_one(itext):
+      i, text = itext
       # Note: This can run out of order, which is a little weird.
       if i in every_5_percent and verbose:
         print('scoring {} of {} ({:.1f}%)'.format(


### PR DESCRIPTION
Wait 24 hours instead of 12. Use the comment's creation time as basis for
waiting instead of bot's scoring time (should be similar, but when bot is
falling behind or when getting historical data, it can be different).

(Based on top of #25 )